### PR TITLE
Rename `WaveorderReader` to `ImageReader`

### DIFF
--- a/iohub/cli/cli.py
+++ b/iohub/cli/cli.py
@@ -1,7 +1,7 @@
 import click
 
 from iohub._version import __version__
-from iohub.reader import WaveorderReader
+from iohub.reader import ImageReader
 
 VERSION = __version__
 
@@ -19,7 +19,7 @@ def info(files):
     """View basic metadata from a list of FILES"""
     for file in files:
         print(f"Reading file:\t {file}")
-        reader = WaveorderReader(file)
+        reader = ImageReader(file)
         print_reader_info(reader)
 
 

--- a/iohub/pycromanager.py
+++ b/iohub/pycromanager.py
@@ -123,7 +123,7 @@ class PycromanagerReader(ReaderBase):
         Data is not loaded into memory.
 
         Note: The behavior of this function is different from other
-        WaveorderReaders as it return a Dask array rather than a zarr array.
+        ImageReader members as it return a Dask array rather than a zarr array.
 
         # TODO: try casting the dask array into a zarr array
         # using `dask.array.to_zarr()`.

--- a/iohub/reader.py
+++ b/iohub/reader.py
@@ -114,7 +114,7 @@ class ImageReader:
         src: str,
         data_type: str = None,
         extract_data: bool = False,
-        log_level: int = logging.ERROR,
+        log_level: int = logging.WARNING,
     ):
         """
         reads data output from micro-manager and returns a zarr array

--- a/iohub/reader.py
+++ b/iohub/reader.py
@@ -32,6 +32,82 @@ from iohub.zarrfile import ZarrReader
 
 
 # todo: add dim_order to all reader objects
+
+
+def _check_zarr_data_type(src: str):
+    try:
+        zarr.open(src, "r")
+    except Exception:
+        return False
+    return True
+
+
+def _check_single_page_tiff(src: str):
+    # pick parent directory in case a .tif file is selected
+    if src.endswith(".tif"):
+        src = os.path.dirname(src)
+
+    files = glob.glob(os.path.join(src, "*.tif"))
+    if len(files) == 0:
+        sub_dirs = _get_sub_dirs(src)
+        if sub_dirs:
+            path = os.path.join(src, sub_dirs[0])
+            files = glob.glob(os.path.join(path, "*.tif"))
+            if len(files) > 0:
+                with tiff.TiffFile(os.path.join(path, files[0])) as tf:
+                    if (
+                        len(tf.pages) == 1
+                    ):  # and tf.pages[0].is_multipage is False:
+                        return True
+    return False
+
+
+def _check_multipage_tiff(src: str):
+    # pick parent directory in case a .tif file is selected
+    if src.endswith(".tif"):
+        src = os.path.dirname(src)
+
+    files = glob.glob(os.path.join(src, "*.tif"))
+    if len(files) > 0:
+        with tiff.TiffFile(files[0]) as tf:
+            if len(tf.pages) > 1:
+                return True
+            elif tf.is_multipage is False and tf.is_ome is True:
+                return True
+    return False
+
+
+def _check_pycromanager(src: str):
+    # go two levels up in case a .tif file is selected
+    if src.endswith(".tif"):
+        src = os.path.abspath(os.path.join(src, "../.."))
+
+    # shortcut, may not be foolproof
+    if os.path.exists(os.path.join(src, "Full resolution", "NDTiff.index")):
+        return True
+    return False
+
+
+def _get_sub_dirs(f: str):
+    """
+    subdir walk
+    from https://github.com/mehta-lab/reconstruct-order
+
+    Parameters
+    ----------
+    f:              (str)
+
+    Returns
+    -------
+    sub_dir_name    (list) natsorted list of subdirectories
+    """
+
+    sub_dir_path = glob.glob(os.path.join(f, "*/"))
+    sub_dir_name = [os.path.split(subdir[:-1])[1] for subdir in sub_dir_path]
+    #    assert subDirName, 'No sub directories found'
+    return natsort.natsorted(sub_dir_name)
+
+
 class WaveorderReader:
     def __init__(
         self,
@@ -65,13 +141,13 @@ class WaveorderReader:
 
         # try to guess data type
         if data_type is None:
-            if WaveorderReader._check_zarr_data_type(src):
+            if _check_zarr_data_type(src):
                 data_type = "zarr"
-            elif WaveorderReader._check_pycromanager(src):
+            elif _check_pycromanager(src):
                 data_type = "pycromanager"
-            elif WaveorderReader._check_multipage_tiff(src):
+            elif _check_multipage_tiff(src):
                 data_type = "ometiff"
-            elif WaveorderReader._check_single_page_tiff(src):
+            elif _check_single_page_tiff(src):
                 data_type = "singlepagetiff"
             else:
                 raise FileNotFoundError(
@@ -95,84 +171,6 @@ class WaveorderReader:
             raise NotImplementedError(
                 f"Reader of type {data_type} is not implemented"
             )
-
-    @staticmethod
-    def _check_zarr_data_type(src):
-        try:
-            zarr.open(src, "r")
-        except Exception:
-            return False
-        return True
-
-    @staticmethod
-    def _check_single_page_tiff(src):
-        # pick parent directory in case a .tif file is selected
-        if src.endswith(".tif"):
-            src = os.path.dirname(src)
-
-        files = glob.glob(os.path.join(src, "*.tif"))
-        if len(files) == 0:
-            sub_dirs = WaveorderReader._get_sub_dirs(src)
-            if sub_dirs:
-                path = os.path.join(src, sub_dirs[0])
-                files = glob.glob(os.path.join(path, "*.tif"))
-                if len(files) > 0:
-                    with tiff.TiffFile(os.path.join(path, files[0])) as tf:
-                        if (
-                            len(tf.pages) == 1
-                        ):  # and tf.pages[0].is_multipage is False:
-                            return True
-        return False
-
-    @staticmethod
-    def _check_multipage_tiff(src):
-        # pick parent directory in case a .tif file is selected
-        if src.endswith(".tif"):
-            src = os.path.dirname(src)
-
-        files = glob.glob(os.path.join(src, "*.tif"))
-        if len(files) > 0:
-            with tiff.TiffFile(files[0]) as tf:
-                if len(tf.pages) > 1:
-                    return True
-                elif tf.is_multipage is False and tf.is_ome is True:
-                    return True
-        return False
-
-    @staticmethod
-    def _check_pycromanager(src):
-        # go two levels up in case a .tif file is selected
-        if src.endswith(".tif"):
-            src = os.path.abspath(os.path.join(src, "../.."))
-
-        # shortcut, may not be foolproof
-        if os.path.exists(
-            os.path.join(src, "Full resolution", "NDTiff.index")
-        ):
-            return True
-        return False
-
-    @staticmethod
-    def _get_sub_dirs(f):
-        """
-        subdir walk
-        from https://github.com/mehta-lab/reconstruct-order
-
-        Parameters
-        ----------
-        f:              (str)
-
-        Returns
-        -------
-        sub_dir_name    (list) natsorted list of subdirectories
-        """
-
-        sub_dir_path = glob.glob(os.path.join(f, "*/"))
-        sub_dir_name = [
-            os.path.split(subdir[:-1])[1] for subdir in sub_dir_path
-        ]
-        #    assert subDirName, 'No sub directories found'
-        return natsort.natsorted(sub_dir_name)
 
     def get_zarr(self, position=0):
         """

--- a/iohub/reader.py
+++ b/iohub/reader.py
@@ -108,7 +108,7 @@ def _get_sub_dirs(f: str):
     return natsort.natsorted(sub_dir_name)
 
 
-class WaveorderReader:
+class ImageReader:
     def __init__(
         self,
         src: str,

--- a/iohub/zarrfile.py
+++ b/iohub/zarrfile.py
@@ -152,7 +152,7 @@ class ZarrReader(ReaderBase):
     def _generate_hcs_meta(self):
         """
         Pulls the HCS metadata and organizes it into a dictionary structure
-        that can be easily read by the WaveorderWriter.
+        that can be easily read by the deprecated Zarr Writer.
 
         Returns
         -------

--- a/iohub/zarrfile.py
+++ b/iohub/zarrfile.py
@@ -1,6 +1,7 @@
 # TODO: remove this in the future (PEP deferred for 3.11, now 3.12?)
 from __future__ import annotations
 
+import logging
 import os
 from copy import copy
 from typing import Literal
@@ -28,6 +29,15 @@ class ZarrReader(ReaderBase):
         self, store_path: str, version: Literal["0.1", "0.4"] = "0.4"
     ):
         super().__init__()
+
+        logging.warning(
+            DeprecationWarning(
+                "`iohub.zarrfile.ZarrReader` is deprecated "
+                "and will be removed in the future. "
+                "For OME-NGFF (OME-Zarr) v0.4 datasets "
+                "please use `iohub.ngff.open_ome_zarr` instead.",
+            )
+        )
 
         # zarr files (.zarr) are directories
         if not os.path.isdir(store_path):

--- a/tests/reader/test_reader.py
+++ b/tests/reader/test_reader.py
@@ -5,7 +5,7 @@ import zarr
 
 from iohub.multipagetiff import MicromanagerOmeTiffReader
 from iohub.pycromanager import PycromanagerReader
-from iohub.reader import WaveorderReader
+from iohub.reader import ImageReader
 from iohub.singlepagetiff import MicromanagerSequenceReader
 
 # todo: consider tests for handling ometiff
@@ -20,7 +20,7 @@ def test_datatype(setup_test_data, setup_mm2gamma_ome_tiffs):
     # choose a specific folder
     _, one_folder, _ = setup_mm2gamma_ome_tiffs
     with pytest.raises(NotImplementedError):
-        _ = WaveorderReader(
+        _ = ImageReader(
             one_folder, data_type="unsupportedformat", extract_data=False
         )
 
@@ -35,7 +35,7 @@ def test_ometiff_constructor_mm2gamma(
     _ = setup_test_data
     # choose a specific folder
     _, one_folder, _ = setup_mm2gamma_ome_tiffs
-    mmr = WaveorderReader(one_folder, extract_data=False)
+    mmr = ImageReader(one_folder, extract_data=False)
 
     assert isinstance(mmr.reader, MicromanagerOmeTiffReader)
 
@@ -55,7 +55,7 @@ def test_ometiff_constructor_mm2gamma(
 def test_ometiff_zarr_mm2gamma(setup_test_data, setup_mm2gamma_ome_tiffs):
     _ = setup_test_data
     _, _, rand_folder = setup_mm2gamma_ome_tiffs
-    mmr = WaveorderReader(rand_folder, extract_data=True)
+    mmr = ImageReader(rand_folder, extract_data=True)
     assert isinstance(mmr.reader, MicromanagerOmeTiffReader)
 
     for i in range(mmr.get_num_positions()):
@@ -67,7 +67,7 @@ def test_ometiff_zarr_mm2gamma(setup_test_data, setup_mm2gamma_ome_tiffs):
 def test_ometiff_array_mm2gamma(setup_test_data, setup_mm2gamma_ome_tiffs):
     _ = setup_test_data
     _, _, rand_folder = setup_mm2gamma_ome_tiffs
-    mmr = WaveorderReader(rand_folder, extract_data=True)
+    mmr = ImageReader(rand_folder, extract_data=True)
 
     assert isinstance(mmr.reader, MicromanagerOmeTiffReader)
 
@@ -83,7 +83,7 @@ def test_sequence_constructor_mm2gamma(
 ):
     _ = setup_test_data
     _, one_folder, _ = setup_mm2gamma_singlepage_tiffs
-    mmr = WaveorderReader(one_folder, extract_data=False)
+    mmr = ImageReader(one_folder, extract_data=False)
 
     assert isinstance(mmr.reader, MicromanagerSequenceReader)
 
@@ -104,7 +104,7 @@ def test_sequence_zarr_mm2gamma(
 ):
     _ = setup_test_data
     _, _, rand_folder = setup_mm2gamma_singlepage_tiffs
-    mmr = WaveorderReader(rand_folder, extract_data=True)
+    mmr = ImageReader(rand_folder, extract_data=True)
 
     assert isinstance(mmr.reader, MicromanagerSequenceReader)
     for i in range(mmr.get_num_positions()):
@@ -118,7 +118,7 @@ def test_sequence_array_zarr_mm2gamma(
 ):
     _ = setup_test_data
     _, _, rand_folder = setup_mm2gamma_singlepage_tiffs
-    mmr = WaveorderReader(rand_folder, extract_data=True)
+    mmr = ImageReader(rand_folder, extract_data=True)
 
     assert isinstance(mmr.reader, MicromanagerSequenceReader)
     for i in range(mmr.get_num_positions()):
@@ -134,7 +134,7 @@ def test_pycromanager_constructor(
     _ = setup_test_data
     # choose a specific folder
     first_dir, rand_dir, ptcz_dir = setup_pycromanager_test_data
-    mmr = WaveorderReader(rand_dir, extract_data=False)
+    mmr = ImageReader(rand_dir, extract_data=False)
 
     assert isinstance(mmr.reader, PycromanagerReader)
 
@@ -154,7 +154,7 @@ def test_pycromanager_constructor(
 def test_pycromanager_get_zarr(setup_test_data, setup_pycromanager_test_data):
     _ = setup_test_data
     first_dir, rand_dir, ptcz_dir = setup_pycromanager_test_data
-    mmr = WaveorderReader(rand_dir)
+    mmr = ImageReader(rand_dir)
     assert isinstance(mmr.reader, PycromanagerReader)
 
     for i in range(mmr.get_num_positions()):
@@ -166,7 +166,7 @@ def test_pycromanager_get_zarr(setup_test_data, setup_pycromanager_test_data):
 def test_pycromanager_get_array(setup_test_data, setup_pycromanager_test_data):
     _ = setup_test_data
     first_dir, rand_dir, ptcz_dir = setup_pycromanager_test_data
-    mmr = WaveorderReader(rand_dir)
+    mmr = ImageReader(rand_dir)
     assert isinstance(mmr.reader, PycromanagerReader)
 
     for i in range(mmr.get_num_positions()):
@@ -180,7 +180,7 @@ def test_ometiff_constructor_mm1422(setup_test_data, setup_mm1422_ome_tiffs):
     _ = setup_test_data
     # choose a specific folder
     _, one_folder, _ = setup_mm1422_ome_tiffs
-    mmr = WaveorderReader(one_folder, extract_data=False)
+    mmr = ImageReader(one_folder, extract_data=False)
 
     assert isinstance(mmr.reader, MicromanagerOmeTiffReader)
 
@@ -200,7 +200,7 @@ def test_ometiff_constructor_mm1422(setup_test_data, setup_mm1422_ome_tiffs):
 def test_ometiff_zarr_mm1422(setup_test_data, setup_mm1422_ome_tiffs):
     _ = setup_test_data
     _, _, rand_folder = setup_mm1422_ome_tiffs
-    mmr = WaveorderReader(rand_folder, extract_data=True)
+    mmr = ImageReader(rand_folder, extract_data=True)
 
     assert isinstance(mmr.reader, MicromanagerOmeTiffReader)
 
@@ -213,7 +213,7 @@ def test_ometiff_zarr_mm1422(setup_test_data, setup_mm1422_ome_tiffs):
 def test_ometiff_array_zarr_mm1422(setup_test_data, setup_mm1422_ome_tiffs):
     _ = setup_test_data
     _, _, rand_folder = setup_mm1422_ome_tiffs
-    mmr = WaveorderReader(rand_folder, extract_data=True)
+    mmr = ImageReader(rand_folder, extract_data=True)
 
     assert isinstance(mmr.reader, MicromanagerOmeTiffReader)
 
@@ -229,7 +229,7 @@ def test_sequence_constructor_mm1422(
 ):
     _ = setup_test_data
     _, one_folder, _ = setup_mm1422_singlepage_tiffs
-    mmr = WaveorderReader(one_folder, extract_data=False)
+    mmr = ImageReader(one_folder, extract_data=False)
 
     assert isinstance(mmr.reader, MicromanagerSequenceReader)
 
@@ -248,7 +248,7 @@ def test_sequence_constructor_mm1422(
 def test_sequence_zarr_mm1422(setup_test_data, setup_mm1422_singlepage_tiffs):
     _ = setup_test_data
     _, _, rand_folder = setup_mm1422_singlepage_tiffs
-    mmr = WaveorderReader(rand_folder, extract_data=True)
+    mmr = ImageReader(rand_folder, extract_data=True)
 
     assert isinstance(mmr.reader, MicromanagerSequenceReader)
 
@@ -263,7 +263,7 @@ def test_sequence_array_zarr_mm1422(
 ):
     _ = setup_test_data
     _, _, rand_folder = setup_mm1422_singlepage_tiffs
-    mmr = WaveorderReader(rand_folder, extract_data=True)
+    mmr = ImageReader(rand_folder, extract_data=True)
 
     assert isinstance(mmr.reader, MicromanagerSequenceReader)
 
@@ -277,7 +277,7 @@ def test_sequence_array_zarr_mm1422(
 def test_height(setup_test_data, setup_mm2gamma_ome_tiffs):
     _ = setup_test_data
     _, _, rand_folder = setup_mm2gamma_ome_tiffs
-    mmr = WaveorderReader(rand_folder, extract_data=False)
+    mmr = ImageReader(rand_folder, extract_data=False)
 
     assert isinstance(mmr.reader, MicromanagerOmeTiffReader)
 
@@ -288,7 +288,7 @@ def test_height(setup_test_data, setup_mm2gamma_ome_tiffs):
 def test_width(setup_test_data, setup_mm2gamma_ome_tiffs):
     _ = setup_test_data
     _, _, rand_folder = setup_mm2gamma_ome_tiffs
-    mmr = WaveorderReader(rand_folder, extract_data=False)
+    mmr = ImageReader(rand_folder, extract_data=False)
 
     assert isinstance(mmr.reader, MicromanagerOmeTiffReader)
 
@@ -299,7 +299,7 @@ def test_width(setup_test_data, setup_mm2gamma_ome_tiffs):
 def test_frames(setup_test_data, setup_mm2gamma_ome_tiffs):
     _ = setup_test_data
     _, _, rand_folder = setup_mm2gamma_ome_tiffs
-    mmr = WaveorderReader(rand_folder, extract_data=False)
+    mmr = ImageReader(rand_folder, extract_data=False)
 
     assert isinstance(mmr.reader, MicromanagerOmeTiffReader)
 
@@ -310,7 +310,7 @@ def test_frames(setup_test_data, setup_mm2gamma_ome_tiffs):
 def test_slices(setup_test_data, setup_mm2gamma_ome_tiffs):
     _ = setup_test_data
     _, _, rand_folder = setup_mm2gamma_ome_tiffs
-    mmr = WaveorderReader(rand_folder, extract_data=False)
+    mmr = ImageReader(rand_folder, extract_data=False)
 
     assert isinstance(mmr.reader, MicromanagerOmeTiffReader)
 
@@ -321,7 +321,7 @@ def test_slices(setup_test_data, setup_mm2gamma_ome_tiffs):
 def test_channels(setup_test_data, setup_mm2gamma_ome_tiffs):
     _ = setup_test_data
     _, _, rand_folder = setup_mm2gamma_ome_tiffs
-    mmr = WaveorderReader(rand_folder, extract_data=False)
+    mmr = ImageReader(rand_folder, extract_data=False)
 
     assert isinstance(mmr.reader, MicromanagerOmeTiffReader)
 
@@ -332,7 +332,7 @@ def test_channels(setup_test_data, setup_mm2gamma_ome_tiffs):
 def test_channel_names(setup_test_data, setup_mm2gamma_ome_tiffs):
     _ = setup_test_data
     _, _, rand_folder = setup_mm2gamma_ome_tiffs
-    mmr = WaveorderReader(rand_folder, extract_data=False)
+    mmr = ImageReader(rand_folder, extract_data=False)
 
     assert isinstance(mmr.reader, MicromanagerOmeTiffReader)
 
@@ -343,7 +343,7 @@ def test_channel_names(setup_test_data, setup_mm2gamma_ome_tiffs):
 def test_mm_meta(setup_test_data, setup_mm2gamma_ome_tiffs):
     _ = setup_test_data
     _, _, rand_folder = setup_mm2gamma_ome_tiffs
-    mmr = WaveorderReader(rand_folder, extract_data=False)
+    mmr = ImageReader(rand_folder, extract_data=False)
 
     assert isinstance(mmr.reader, MicromanagerOmeTiffReader)
 
@@ -357,7 +357,7 @@ def test_mm_meta(setup_test_data, setup_mm2gamma_ome_tiffs):
 def test_stage_positions(setup_test_data, setup_mm2gamma_ome_tiffs):
     _ = setup_test_data
     _, _, rand_folder = setup_mm2gamma_ome_tiffs
-    mmr = WaveorderReader(rand_folder, extract_data=False)
+    mmr = ImageReader(rand_folder, extract_data=False)
 
     assert isinstance(mmr.reader, MicromanagerOmeTiffReader)
 
@@ -371,7 +371,7 @@ def test_stage_positions(setup_test_data, setup_mm2gamma_ome_tiffs):
 def test_z_step_size(setup_test_data, setup_mm2gamma_ome_tiffs):
     _ = setup_test_data
     _, _, rand_folder = setup_mm2gamma_ome_tiffs
-    mmr = WaveorderReader(rand_folder, extract_data=False)
+    mmr = ImageReader(rand_folder, extract_data=False)
 
     assert isinstance(mmr.reader, MicromanagerOmeTiffReader)
 

--- a/tests/reader/test_zarrfile.py
+++ b/tests/reader/test_zarrfile.py
@@ -1,7 +1,7 @@
 import numpy as np
 import zarr
 
-from iohub.reader import WaveorderReader
+from iohub.reader import ImageReader
 from iohub.zarrfile import ZarrReader
 
 
@@ -14,7 +14,7 @@ def test_constructor_mm2gamma(setup_test_data, setup_mm2gamma_zarr):
     _ = setup_test_data
     src = setup_mm2gamma_zarr
 
-    reader = WaveorderReader(src)
+    reader = ImageReader(src)
     assert isinstance(reader.reader, ZarrReader)
 
     mmr = ZarrReader(src)


### PR DESCRIPTION
This PR does a shallow renaming: the legacy `WaveorderReader` class is now `ImageReader`. Otherwise API remains the same.