### PR TITLE
Add zarr to install_requires

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -39,6 +39,8 @@ install_requires =
     tifffile>=2021.11.2
     natsort>=7.1.1
     ndtiff>=1.9.0
+    zarr
+    
 
 [options.extras_require]
 dev =


### PR DESCRIPTION
This PR adds `zarr` to `iohub`'s `install_requires`.

A from-scratch install of `iohub` showed that `from iohub.reader import ImageReader` fails since `zarr` isn't an explicit dependency.