### PR TITLE
Makes examples output directory temporary

### DIFF
--- a/examples/multi_fov_hcs_ome_zarr.py
+++ b/examples/multi_fov_hcs_ome_zarr.py
@@ -14,6 +14,7 @@ from iohub.ngff import open_ome_zarr
 # Set storage path
 
 store_path = f"{tempfile.gettempdir()}/hcs.zarr"
+print("Zarr store path", store_path)
 
 # %%
 # Write 5D data to multiple wells.
@@ -59,3 +60,4 @@ with open_ome_zarr(store_path, mode="r+") as dataset:
 
 # %%
 # Try viewing the images with napari-ome-zarr
+print("Zarr store path", store_path)

--- a/examples/multi_fov_hcs_ome_zarr.py
+++ b/examples/multi_fov_hcs_ome_zarr.py
@@ -4,7 +4,7 @@
 # and adds an extra well-position to an existing dataset.
 # It can be run as a plain Python script, or as interactive cells in some IDEs.
 
-import os
+import tempfile
 
 import numpy as np
 
@@ -13,7 +13,7 @@ from iohub.ngff import open_ome_zarr
 # %%
 # Set storage path
 
-store_path = f'{os.path.expanduser("~/")}hcs.zarr'
+store_path = f"{tempfile.gettempdir()}/hcs.zarr"
 
 # %%
 # Write 5D data to multiple wells.

--- a/examples/single_fov_ome_zarr.py
+++ b/examples/single_fov_ome_zarr.py
@@ -16,6 +16,7 @@ from iohub.ngff import open_ome_zarr
 # Set storage path
 
 store_path = f"{tempfile.gettempdir()}/ome.zarr"
+print("Zarr store path", store_path)
 
 # %%
 # Write 5D data to a new Zarr store
@@ -90,3 +91,4 @@ dataset.close()
 
 # %%
 # Try viewing the images with napari-ome-zarr
+print("Zarr store path", store_path)

--- a/examples/single_fov_ome_zarr.py
+++ b/examples/single_fov_ome_zarr.py
@@ -6,7 +6,7 @@
 # It can be run as a plain Python script,
 # or as interactive cells in some IDEs.
 
-import os
+import tempfile
 
 import numpy as np
 
@@ -15,7 +15,7 @@ from iohub.ngff import open_ome_zarr
 # %%
 # Set storage path
 
-store_path = f'{os.path.expanduser("~/")}ome.zarr'
+store_path = f"{tempfile.gettempdir()}/ome.zarr"
 
 # %%
 # Write 5D data to a new Zarr store


### PR DESCRIPTION
Swap the output directory from $HOME to a temporary directory.

I notice that the examples can be run as notebooks, if we're ok with removing this feature I could add `__name__ == __main__` to this PR.