### PR TITLE
Initialize Zarr arrays in TIFF readers as zero-filled

### DIFF
--- a/iohub/convert.py
+++ b/iohub/convert.py
@@ -268,7 +268,12 @@ class TIFFConverter:
                 self.pos_names.append(name)
 
     def _get_image_array(self, p: int, t: int, c: int, z: int):
-        return np.asarray(self.reader.get_image(p, t, c, z))
+        try:
+            return np.asarray(self.reader.get_image(p, t, c, z))
+        except KeyError:
+            # Converter will log a warning and
+            # fill zeros if the image does not exist
+            return None
 
     def _get_coord_reorder(self, coord):
         return (

--- a/iohub/multipagetiff.py
+++ b/iohub/multipagetiff.py
@@ -266,7 +266,7 @@ class MicromanagerOmeTiffReader(ReaderBase):
 
         # intialize virtual zarr store and save it under positions
         timepoints, channels, slices = self._get_dimensions(pos)
-        self.position_arrays[pos] = zarr.empty(
+        self.position_arrays[pos] = zarr.zeros(
             shape=(timepoints, channels, slices, self.height, self.width),
             chunks=(1, 1, 1, self.height, self.width),
             dtype=self.dtype,

--- a/iohub/upti.py
+++ b/iohub/upti.py
@@ -117,7 +117,7 @@ class UPTIReader(ReaderBase):
 
         """
 
-        self.position_arrays[pos] = zarr.empty(
+        self.position_arrays[pos] = zarr.zeros(
             shape=(
                 self.frames,
                 self.channels,


### PR DESCRIPTION
Fixes #82 and https://github.com/mehta-lab/recOrder/issues/327#issuecomment-1479897823.

The converter will now log a warning and fill with zeros instead of throwing an error if certain images are not present in the OME-TIFF series.

Edit: Test that repeated reads return the same values.

```python
In [1]: from iohub.reader import imread

In [2]: reader = imread('/hpc/projects/compmicro/rawdata/other/NIC QLIPP/2022_12_01 PtK cells/FOV1_1')

In [4]: reader.get_zarr(0)[0,-1,:,500,500]
Out[4]:
array([  0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,
         0,   0,   0,   0,   0,   0,   0, 631,   0,   0,   0,   0,   0,
         0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,
         0,   0], dtype=uint16)

In [5]: reader.get_zarr(0)[0,-1,:,500,500]
Out[5]:
array([  0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,
         0,   0,   0,   0,   0,   0,   0, 631,   0,   0,   0,   0,   0,
         0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,
         0,   0], dtype=uint16)

In [6]: reader.get_zarr(0)[0,-1,:,500,500]
Out[6]:
array([  0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,
         0,   0,   0,   0,   0,   0,   0, 631,   0,   0,   0,   0,   0,
         0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,   0,
         0,   0], dtype=uint16)
```