### PR TITLE
Use fixed separator `/` to join row_name and col_name

### DIFF
--- a/iohub/ngff.py
+++ b/iohub/ngff.py
@@ -1263,7 +1263,7 @@ class Plate(NGFFNode):
         col_index = self._auto_idx(col_index, self._cols)
         # build well metadata
         well_index_meta = WellIndexMeta(
-            path=os.path.join(row_name, col_name),
+            path='/'.join([row_name, col_name]),
             row_index=row_index,
             column_index=col_index,
         )


### PR DESCRIPTION
`os.path.join` uses different separators (`/` or `\`) to join paths, but the NGFF spec only uses `/`. 

The pydantic validator correctly only admits `/`, so it complained when I tried to convert a dataset to ome-zarr v0.4 using the iohub converter on the hummingbird machine. 

I have tested this fix on hummingbird and my personal machine.