### PR TITLE
Fix `setuptools-scm` installation error

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,8 +1,9 @@
 [build-system]
-requires = ["setuptools", "wheel", "setuptools_scm"]
+requires = ["setuptools", "wheel", "setuptools_scm[toml]"]
 build-backend = "setuptools.build_meta"
 
 [tool.setuptools_scm]
+version_scheme = "release-branch-semver"
 write_to = "iohub/_version.py"
 
 [tool.black]


### PR DESCRIPTION
Fixes #123. I needed a dev installation to test the `convert` command. 

Copied from https://stackoverflow.com/a/71488066, and I tested that it works. Feel free to modify. 