### PR TITLE
Fix multiversion links

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -31,7 +31,10 @@ jobs:
           pip install ".[doc]"
       - name: Build the docs
         working-directory: ./docs
-        run: make publish
+        run: |
+          make publish
+          touch build/html/.nojekyll
+          cp gh-pages-redirect.html html/index.html
       - name: Upload build artifacts
         uses: actions/upload-pages-artifact@v1
         with:

--- a/docs/gh-pages-redirect.html
+++ b/docs/gh-pages-redirect.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Redirecting to main branch</title>
+    <meta charset="utf-8">
+    <meta http-equiv="refresh" content="0; url=./main/index.html">
+    <link rel="canonical" href="https://czbiohub.github.io/iohub/main/index.html">
+  </head>
+</html>

--- a/docs/source/_static/switcher.json
+++ b/docs/source/_static/switcher.json
@@ -4,7 +4,7 @@
         "url": "https://czbiohub/main/index.html"
     },
     {
-        "version": "0.1.0dev2",
-        "url": "https://mysite.org/en/v0.1.0dev2/index.html"
+        "version": "0.1.0dev3",
+        "url": "https://mysite.org/en/v0.1.0dev3/index.html"
     }
 ]

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -37,8 +37,13 @@ extensions = [
     "sphinx_copybutton",
     "numpydoc",
     "sphinx_multiversion",
+    "sphinx_sitemap",
 ]
 
+# default url is a dummy for local build
+html_baseurl = os.environ.get("SITEMAP_URL_BASE", "htrp://127.0.0.1:8000/")
+sitemap_locales = ["en"]
+sitemap_url_scheme = "{link}"
 
 numpydoc_show_class_members = True
 
@@ -63,7 +68,7 @@ project = "iohub"
 copyright = "2023. Chan Zuckerberg Biohub. All rights reserved"
 release = importlib_metadata.version("iohub")
 
-json_url = "https://czbiohub.github.io/iohub/latest/_static/switcher.json"
+json_url = "https://czbiohub.github.io/iohub/main/_static/switcher.json"
 if "dev" in release or "rc" in release:
     json_url = "_static/switcher.json"
     version_match = "latest"
@@ -118,7 +123,7 @@ html_theme_options = {
         "json_url": json_url,
         "version_match": version_match,
     },
-    "navbar_end": ["theme-switcher", "version-switcher", "navbar-icon-links"]
+    "navbar_end": ["theme-switcher", "version-switcher", "navbar-icon-links"],
 }
 
 # Add any paths that contain custom themes here, relative to this directory.
@@ -193,3 +198,4 @@ htmlhelp_basename = "iohubdoc"
 numpydoc_show_class_members = False
 
 smv_branch_whitelist = r"main"
+smv_latest_version = r"main"

--- a/setup.cfg
+++ b/setup.cfg
@@ -55,3 +55,4 @@ doc =
     pydata-sphinx-theme==0.13.3
     sphinx-copybutton==0.4.0
     sphinx-multiversion==0.2.4
+    sphinx-sitemap==2.5.0


### PR DESCRIPTION
Building docs with sphinx-multiversion does not automatically generate a root `index.html` file. So currently the [czbiohub.github.io/iohub/](https://czbiohub.github.io/iohub/) link is broken, and the docs for main needs to be accessed from https://czbiohub.github.io/iohub/main.

The index needs to be manually generated according to the extension's [documentation](https://holzhaus.github.io/sphinx-multiversion/master/github_pages.html#redirecting-from-the-document-root).