### PR TITLE
Convert a list of input datasets

### DIFF
--- a/iohub/cli/cli.py
+++ b/iohub/cli/cli.py
@@ -94,7 +94,14 @@ def info(datasets, verbose):
 def convert(
     input_datasets, output, format, scale_voxels, grid_layout, label_positions
 ):
-    """Converts Micro-Manager TIFF datasets to OME-Zarr"""
+    """Converts Micro-Manager TIFF datasets to OME-Zarr
+
+    Example:
+
+    >> iohub convert /glob/of/ome-tiff/folders/*
+
+    will convert all ome-tiff folders to .zarr datasets in the current directory.
+    """
 
     for input_dataset in input_datasets:
         click.echo(f"Converting dataset:\t {input_dataset}")

--- a/iohub/cli/cli.py
+++ b/iohub/cli/cli.py
@@ -60,7 +60,7 @@ def info(datasets, verbose):
     required=False,
     type=click.Path(exists=False, resolve_path=True),
     default="./",
-    help="""Path to output. Defaults to the current directory with the input 
+    help="""Path to output. Defaults to the current directory with the input
     dataset's name.""",
 )
 @click.option(

--- a/iohub/cli/cli.py
+++ b/iohub/cli/cli.py
@@ -1,5 +1,6 @@
-import click
 import os
+
+import click
 
 from iohub._version import __version__
 from iohub.convert import TIFFConverter
@@ -59,7 +60,8 @@ def info(datasets, verbose):
     required=False,
     type=click.Path(exists=False, resolve_path=True),
     default="./",
-    help="Path to output. Defaults to the current directory with the input dataset's name.",
+    help="""Path to output. Defaults to the current directory with the input 
+    dataset's name.""",
 )
 @click.option(
     "--format",
@@ -100,7 +102,8 @@ def convert(
 
     >> iohub convert /glob/of/ome-tiff/folders/*
 
-    will convert all ome-tiff folders to .zarr datasets in the current directory.
+    will convert all ome-tiff folders to .zarr datasets in the current
+    directory.
     """
 
     for input_dataset in input_datasets:


### PR DESCRIPTION
The current CLI for `convert` is `iohub convert -i <input-ome-tiff-folder> -o <output.zarr>`. 

In my experience/opinion this is a bit clunky because it requires you to
- type out the dataset name twice (once for input, once for output), 
- specify `.zarr` unnecessarily, and 
- it's not compatible with wildcards. 

This PR changes the interface to `iohub convert /glob/of/ome-tiff/folders/*` with an optional `-o <output-folder>` parameter that defaults to the current directory. 

In practice, I almost always want to convert all of the datasets within a folder, and I want to duplicate the folder names. So, for example, `iohub convert /path/to/project/*` will fill my current directory with the converted `.zarrs`. 

