### PR TITLE
Print number of positions in `iohub info`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,7 @@
 repos:
 # basic pre-commit
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.1.0
+    rev: v4.4.0
     hooks:
       - id: trailing-whitespace
       - id: end-of-file-fixer
@@ -11,23 +11,23 @@ repos:
       - id: detect-private-key
 # sorting imports
   - repo: https://github.com/pycqa/isort
-    rev: 5.10.1
+    rev: 5.12.0
     hooks:
       - id: isort
 # syntax linting and formatting
   - repo: https://github.com/myint/autoflake
-    rev: v1.4
+    rev: v2.1.1
     hooks:
       - id: autoflake
         args: [--in-place, --remove-all-unused-imports,
                --ignore-init-module-imports]
   - repo: https://github.com/PyCQA/flake8
-    rev: 4.0.1
+    rev: 6.0.0
     hooks:
       - id: flake8
         args: [--ignore, "E203,W503", --min-python-version, '3.9']
         additional_dependencies: [flake8-typing-imports==1.12.0]
   - repo: https://github.com/psf/black
-    rev: 22.3.0
+    rev: 23.3.0
     hooks:
       - id: black

--- a/iohub/reader.py
+++ b/iohub/reader.py
@@ -302,6 +302,7 @@ def print_info(path: StrOrBytesPath, verbose=False):
                     f"Row names:\t {[r.name for r in meta.rows]}",
                     f"Column names:\t {[c.name for c in meta.columns]}",
                     f"Wells:\t\t {len(meta.wells)}",
+                    f"Positions:\t {len(list(reader.positions()))}",
                 ]
             )
         if verbose:

--- a/iohub/reader.py
+++ b/iohub/reader.py
@@ -302,12 +302,13 @@ def print_info(path: StrOrBytesPath, verbose=False):
                     f"Row names:\t {[r.name for r in meta.rows]}",
                     f"Column names:\t {[c.name for c in meta.columns]}",
                     f"Wells:\t\t {len(meta.wells)}",
-                    f"Positions:\t {len(list(reader.positions()))}",
+                    
                 ]
             )
         if verbose:
             msgs.extend(
                 [
+                    f"Positions:\t {len(list(reader.positions()))}",                    
                     code_msg,
                     ">>> from iohub import open_ome_zarr",
                     f">>> dataset = open_ome_zarr('{path}', mode='r')",

--- a/iohub/reader.py
+++ b/iohub/reader.py
@@ -302,13 +302,12 @@ def print_info(path: StrOrBytesPath, verbose=False):
                     f"Row names:\t {[r.name for r in meta.rows]}",
                     f"Column names:\t {[c.name for c in meta.columns]}",
                     f"Wells:\t\t {len(meta.wells)}",
-                    
                 ]
             )
         if verbose:
             msgs.extend(
                 [
-                    f"Positions:\t {len(list(reader.positions()))}",                    
+                    f"Positions:\t {len(list(reader.positions()))}",
                     code_msg,
                     ">>> from iohub import open_ome_zarr",
                     f">>> dataset = open_ome_zarr('{path}', mode='r')",


### PR DESCRIPTION
When I saw an `iohub info` result like this:
```
=== Summary ===
Format:		 omezarr v0.4
Axes:		 T (time); C (channel); Z (space); Y (space); X (space); 
Channel names:	 ['GFP EX488 EM525-45', 'mCherry EX561 EM600-37']
Row names:	 ['0']
Column names:	 ['0']
Wells:		 1
```
I didn't realize that the zarr store actually had multiple positions. 

This PR adds one line to the output to show the user the total number of positions:
```
Positions:	 5
```